### PR TITLE
fix dep reference

### DIFF
--- a/babel-plugin-csstag/package.json
+++ b/babel-plugin-csstag/package.json
@@ -3,7 +3,7 @@
   "name": "babel-plugin-csstag",
   "dependencies": {
     "clean-css": "^4.2.1",
-    "csstag": "file:.."
+    "csstag": "0.x.x"
   },
   "description": "Babel plugin for compiling CSS Modules in csstag's tagged templates to actual styles for production.",
   "homepage": "https://github.com/sgtpep/csstag/tree/master/babel-plugin-csstag",


### PR DESCRIPTION
The published version of this module cannot install because "file:.." doesn't work outside of the scope of this directory structure.